### PR TITLE
Fix for GOPATH not set

### DIFF
--- a/cog.go
+++ b/cog.go
@@ -6,6 +6,7 @@
 package cog
 
 import (
+	"go/build"
 	"os"
 )
 
@@ -22,7 +23,14 @@ type Cog interface {
 
 func init() {
 
+	var gopath string
+	gp := os.Getenv("GOPATH")
+	if gp != "" {
+		gopath = gp
+	} else {
+		gopath = build.Default.GOPATH
+	}
 	DefaultTemplatesDirectoryName = "templates"
-	DefaultGoSourcePath = os.Getenv("GOPATH") + "/src"
+	DefaultGoSourcePath = gopath + "/src"
 
 }


### PR DESCRIPTION
This change accounts for a GOPATH that isn't set, but relies on the n…ew defaulted GOPATH.